### PR TITLE
New Simplified API, tests fixes, new supported sensor and more

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-core"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,6 +356,7 @@ dependencies = [
  "rppal",
  "serde",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -517,6 +530,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ log = "0.4.17"
 rppal = "0.13.1"
 serde = { version = "1.0.144", features = ["derive"] }
 tokio = { version = "1.23.0", features = ["full"]}
+tokio-util = "0.7.7"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ However, because it's very cheap, it can detects "noise" from time to time, whic
 
 To eliminate this problem I created this simple library which allows to initialize this sensor with various parameters that they changes it's detection characteristic. The library, based on sensor configuration, can "ignore" these false detections and help make this sensors very reliable.
 
-HC-SR501 PIR is not probably the only one infrared sensor which can be supported by the library - if you tested with another motion sensor please let me know. Digital microwave sensor like DFRobot SEN0192 is also supported (keep in mind it may set High->Low state once detection happens)
+HC-SR501 PIR is not probably the only one infrared sensor which can be supported by the library - if you tested with another motion sensor please let me know. 
+
+Digital microwave sensor like DFRobot SEN0192 is also supported, but keep in mind that SEN0192 sets from `High` to `Low` state once detection happens, so you have to [simply invert this signal by a proper transistor in your circuit to take advantage of this library](https://en.wikipedia.org/wiki/Inverter_(logic_gate)).
 
 &nbsp;
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To eliminate this problem I created this simple library which allows to initiali
 
 HC-SR501 PIR is not probably the only one infrared sensor which can be supported by the library - if you tested with another motion sensor please let me know. 
 
-Digital microwave sensor like DFRobot SEN0192 is also supported, but keep in mind that SEN0192 sets from `High` to `Low` state once detection happens, so you have to [simply invert this signal by a proper transistor in your circuit to take advantage of this library](https://en.wikipedia.org/wiki/Inverter_(logic_gate)).
+Digital microwave sensor like DFRobot SEN0192 is also supported, but keep in mind that SEN0192 sets from `High` to `Low` state once detection happens, so you have to [simply invert this signal by a proper transistor in your circuit to take advantage of this library](https://en.wikipedia.org/wiki/Inverter_(logic_gate)). Currently I have no plan to implement alternative logic for such sensors.
 
 &nbsp;
 
@@ -28,6 +28,7 @@ Raspberry Pis:
 Tested motion sensors:
 
 - HC-SR501 PIR (infrared)
+- HC-SR505 (infrared - basic support as you can't change factory values of this simple sensor)
 - DFRobot SEN0192 (microwave)
 
 &nbsp;
@@ -60,8 +61,6 @@ In this instruction, there is a term `valid detection` - this is a detection whi
 
 In other words: depends on sensor configuration, there can be many detections made by sensor (here defined as setting it's OUT pin at high state), but it does not mean, there will be single `valid detection` classified.
 
-
-
 &nbsp;
 
 ## Configuration
@@ -88,7 +87,7 @@ To conclude these parameters shortly: based on `sensor refresh rate` time, the l
 Setting these parameters allows you to decide how sensitive and accurate is your sensor. Because "noise" detections are usually very short hence using this library you can effectively get rid of them if your settings are not too sensitive (good tested values: `sensor_refresh_rate > 100`, `motion_time_period < 1000`, `minimal_triggering_number > 2`). Feel free to experiment with your own
 values.
 
-Keep in mind that these settings affect each other, for instance: a very short `sensor_refresh_rate` can be reduced by higher values of `motion_time_period` and `minimal_triggering_number`
+Keep in mind that these settings can affect each other, for instance: a very short `sensor_refresh_rate` can be reduced by higher values of `motion_time_period` and `minimal_triggering_number`
 
 &nbsp;
 ## Using in your project

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## pir-motion-sensor
 
-Rust library to interact mainly with PIR motion sensors on Raspberry Pi platform. This lib was tested on HC-SR501 motion sensor on Raspberry Pi 400 and Raspberry Pi 4B and it's widely used at my appartment and at my family's house - for smart alarm purposes (rest code will be published) and some in-house activies like turning on/off various devices based on motion detection.
+Rust library to interact mainly with PIR motion sensors on Raspberry Pi platform. This lib was tested mainly on HC-SR501 motion sensor on Raspberry Pi 400 and Raspberry Pi 4B and it's widely used at my appartment and at my family's house - for smart alarm purposes (rest code will be published) and some in-house activies like turning on/off various devices based on motion detection.
 
 &nbsp;
 
@@ -12,19 +12,21 @@ However, because it's very cheap, it can detects "noise" from time to time, whic
 
 To eliminate this problem I created this simple library which allows to initialize this sensor with various parameters that they changes it's detection characteristic. The library, based on sensor configuration, can "ignore" these false detections and help make this sensors very reliable.
 
-HC-SR501 PIR is not probably the only one infrared sensor which can be supported by the library - if you tested with another motion sensor (or even with microwave) please let me know.
+HC-SR501 PIR is not probably the only one infrared sensor which can be supported by the library - if you tested with another motion sensor please let me know. Digital microwave sensor like DFRobot SEN0192 is also supported (keep in mind it may set High->Low state once detection happens)
 
 &nbsp;
 
 ## Tested devices
 
 Raspberry Pis:
+
 - Raspberry Pi 4B 4 and 8 GB RAM - Raspbian GNU/Linux 11 (bullseye)
 - Raspbbery Pi 400 4 GB RAM - Raspbian GNU/Linux 11 (bullseye)
 
-Sensors:
+Tested motion sensors:
 
-- HC-SR501 PIR
+- HC-SR501 PIR (infrared)
+- DFRobot SEN0192 (microwave)
 
 &nbsp;
 

--- a/src/sensor/config.rs
+++ b/src/sensor/config.rs
@@ -4,7 +4,7 @@ use serde::Deserialize;
 pub struct SensorConfig {
     pub name: String,
     pub pin_number: u8,
-    pub refresh_rate_milisecs: u128,      // miliseconds
+    pub refresh_rate_milisecs: u64,       // miliseconds
     pub motion_time_period_milisecs: u64, // miliseconds
     pub minimal_triggering_number: i16,
 }

--- a/src/sensor/helpers.rs
+++ b/src/sensor/helpers.rs
@@ -1,12 +1,20 @@
 use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
 
 use crate::sensor::motion::MotionSensor;
 use std::sync::Arc;
 
-pub async fn process_detections_data(sensor: Vec<Arc<Mutex<MotionSensor>>>) {
+pub async fn process_detections_data(
+    sensor: Vec<Arc<Mutex<MotionSensor>>>,
+    process: CancellationToken,
+) {
     let mut detection_data: Vec<(i16, Instant)> = vec![(0, Instant::now()); sensor.len()];
     loop {
+        if process.is_cancelled() {
+            break;
+        }
+
         let s = sensor.clone();
         for (idx, r) in s.iter().enumerate() {
             let (last_trigger_count, last_check_time) = detection_data[idx];
@@ -18,18 +26,38 @@ pub async fn process_detections_data(sensor: Vec<Arc<Mutex<MotionSensor>>>) {
                 detection_data[idx] = (tmp_trigger, tmp_time);
             }
         }
-        tokio::time::sleep(Duration::from_millis(1)).await;
+        tokio::time::sleep(Duration::from_micros(100)).await;
     }
 }
 
-pub async fn reading_data_from_sensors(sensors: Vec<Arc<Mutex<MotionSensor>>>) {
+pub async fn reading_data_from_sensors(
+    sensors: Vec<Arc<Mutex<MotionSensor>>>,
+    reading: CancellationToken,
+) {
     loop {
+        if reading.is_cancelled() {
+            break;
+        }
+
         let s = sensors.clone();
         for r in s.iter() {
             if let Ok(mut data) = r.try_lock() {
                 data.reading_from_sensor().await;
             }
         }
-        tokio::time::sleep(Duration::from_millis(1)).await;
+        tokio::time::sleep(Duration::from_micros(100)).await;
     }
+}
+
+pub fn spawn_detection_threads(
+    sensors: Vec<Arc<Mutex<MotionSensor>>>,
+    stop_command: CancellationToken,
+) {
+    let sensors_copy = sensors.clone();
+    let token_copy = stop_command.clone();
+    tokio::spawn(async move { process_detections_data(sensors, stop_command.clone()).await });
+
+    tokio::spawn(async move {
+        reading_data_from_sensors(sensors_copy, token_copy).await;
+    });
 }

--- a/tests/valid_detections.rs
+++ b/tests/valid_detections.rs
@@ -1,9 +1,10 @@
 use pir_motion_sensor::sensor::motion::MotionSensor;
+use tokio_util::sync::CancellationToken;
 
 struct TestCase {
     sensor: MotionSensor,
     expected_detections_count: u64,
-    test_timeout_milisecs: u128,
+    test_timeout_milisecs: u64,
 }
 
 #[cfg(test)]
@@ -13,7 +14,7 @@ mod tests {
         time::{Duration, Instant, SystemTime},
     };
 
-    use pir_motion_sensor::sensor::helpers::{process_detections_data, reading_data_from_sensors};
+    use pir_motion_sensor::sensor::helpers::spawn_detection_threads;
     use tokio::sync::mpsc::{self, Receiver, Sender};
     use tokio::sync::Mutex;
 
@@ -25,34 +26,38 @@ mod tests {
         let (detections_channel_in, mut detections_channel_out): (
             Sender<(String, SystemTime)>,
             Receiver<(String, SystemTime)>,
-        ) = mpsc::channel(100);
+        ) = mpsc::channel(10);
 
         let test_cases_list: Vec<TestCase> = vec![
             TestCase {
                 //
-                // Test Case: we have two detection, one at 500 milisec, another at 1000 milisec.
+                // Test Case: we have two detection, one at 490 milisec, another at 990 milisec.
                 //            because sensor refresh rate is 500 milisec, one detection will be recognized
                 //            in period 0-500 milisec, another in period 500-1000 milisec. Because there are
                 //            two detections, sensor configuration in this test (required number of detection to classify)
                 //            will classify them as 1 valid detection and this is our expected number as a value for
-                //            expected detections count
+                //            expected detections count.
                 //
                 sensor: MotionSensor::new(
-                    String::from("SensorValidDetections1"), // name of the sensor
-                    0,                                      // pin number - not relevant in tests
-                    500,                                    // sensor refresh rate in miliseconds
-                    1000,                                   // motion time period in miliseconds
+                    String::from("SensorSimpleDetection"), // name of the sensor
+                    0,                                     // pin number - not relevant in tests
+                    500,                                   // sensor refresh rate in miliseconds
+                    1000,                                  // motion time period in miliseconds
                     2, // required number of detection to classify
                     detections_channel_in.clone(),
-                    Some(vec![500, 1000]), // at which milisec detection happens, here at 500 ms and 1000 ms
+                    Some(vec![490, 990]), // at which milisec test detection happen, here at 490 ms and 500 ms
+                                          //
+                                          // WARNING: to have deterministic results it's good to keeping these detections moments
+                                          //          around 10 milisec "away" from sensor refresh rate. If you set values on the edge of
+                                          //          sensor refresh rate then test result may not be deterministic (sometimes test will fail)
                 ),
                 expected_detections_count: 1, // how many "valid" detections will be classified based on sensor and detection configurations
-                test_timeout_milisecs: 1100, // timeout for the test (miliseconds) - after this moment we stop sensor thread, it's good
-                                             // to set timeout about +100 miliseconds more than last test detection
+                test_timeout_milisecs: 1050, // timeout for the test (miliseconds) - after this moment we stop sensor thread, it's good
+                                             // to set timeout about +50 miliseconds more than last test detection
             },
             TestCase {
                 //
-                // Test Case: here we have six testing detections at 100, 200, 300, 400, 500 and 501 milisecs
+                // Test Case: here we have six testing detections at 90, 190, 290, 390, 490 and 501 milisecs
                 //            sensor refresh rate is 100 milisec and motion period is checked for 500 msec and requires
                 //            5 detections to classify them as 1 "valid". So in this test we expect 1 valid detection,
                 //            as detection at 501 milisecs is after limit of motion time period.
@@ -65,11 +70,10 @@ mod tests {
                     500,                                    // motion time period in miliseconds
                     5, // required number of detection to classify
                     detections_channel_in.clone(),
-                    Some(vec![100, 200, 300, 400, 500, 501]), // at which milisec detection happens, here at 500 ms and 1000 ms
+                    Some(vec![90, 190, 290, 390, 490, 501]), // at which milisec test detection happen
                 ),
                 expected_detections_count: 1, // how many "valid" detections will be classified based on sensor and detection configurations
-                test_timeout_milisecs: 550, // timeout for the test (miliseconds) - after this moment we stop sensor thread, it's good
-                                            // to set timeout about +50 miliseconds more than last test detection
+                test_timeout_milisecs: 550, // timeout for the test (miliseconds) - after this moment we stop sensor thread,
             },
             TestCase {
                 //
@@ -85,46 +89,48 @@ mod tests {
                     500,                                    // motion time period in miliseconds
                     5, // required number of detection to classify
                     detections_channel_in.clone(),
-                    Some(vec![100, 200, 300, 400, 500, 501, 520, 540, 560, 1001]), // at which milisec detection happens
+                    Some(vec![90, 190, 290, 390, 490, 550, 650, 750, 950, 1010]), // at which milisec test detection happen
                 ),
                 expected_detections_count: 1, // how many "valid" detections will be classified based on sensor and detection configurations
-                test_timeout_milisecs: 1100, // timeout for the test (miliseconds) - after this moment we stop sensor thread,
+                test_timeout_milisecs: 1020, // timeout for the test (miliseconds) - after this moment we stop sensor thread,
             },
             TestCase {
+                //
+                // Test Case: there is a quick refresh rate (100 milisec) and only 1 detection
+                //            is required to classify a valid detection. This test makes 10 detections, each in another
+                //            iteration of sensor refresh rate so we try to achieve 10 valid detections here
+                //
+                //
                 sensor: MotionSensor::new(
-                    String::from("SensorValidDetections3_ManyDetections"),
-                    0,
-                    100,
-                    200,
-                    1,
+                    String::from("SensorValidDetections3_ManyDetections"), // name of the sensor
+                    0,   // pin number - not relevant in tests
+                    100, // sensor refresh rate in miliseconds
+                    200, // motion time period in miliseconds
+                    1,   // required number of detection to classify
                     detections_channel_in.clone(),
-                    Some(vec![100, 200, 300, 400, 500, 600, 700, 800, 900, 1000]),
+                    Some(vec![90, 190, 290, 390, 490, 590, 690, 790, 890, 990]), // at which milisec test detections happen
                 ),
                 expected_detections_count: 10, // 10 because we can count all of these detections
-                test_timeout_milisecs: 1100,
+                test_timeout_milisecs: 1050, // timeout for the test (miliseconds) - after this moment we stop sensor thread,
             },
             TestCase {
-                /*
-                 */
+                //
+                // Test Case: similar as previous but this time motion_time_period=1000 ms - it means we should count only
+                //            one VALID detection instead of 10 as previous.
+                //
                 sensor: MotionSensor::new(
-                    String::from("SensorValidDetections4_OneBigDetection"),
-                    0,
-                    100,
-                    1000,
-                    10,
+                    String::from("SensorValidDetections4_OneBigDetection"), // name of sensor
+                    0,    // pin number - not relevant in tests
+                    100,  // sensor refresh rate in miliseconds
+                    1000, // motion time period in miliseconds
+                    10,   // required number of detection to classify
                     detections_channel_in,
-                    Some(vec![100, 200, 300, 400, 500, 600, 700, 800, 900, 1000]),
+                    Some(vec![90, 190, 290, 390, 490, 590, 690, 790, 890, 990]), // at which milisec test detections happen
                 ),
                 expected_detections_count: 1, // only 1 because motion time period is 1000 milisecs
-                test_timeout_milisecs: 1100,
+                test_timeout_milisecs: 1050, // timeout for the test (miliseconds) - after this moment we stop sensor thread
             },
         ];
-
-        // #[allow(clippy::type_complexity)]
-        // let (detections_channel_sender, mut detections_channel_receiver): (
-        //     Sender<(String, SystemTime)>,
-        //     Receiver<(String, SystemTime)>,
-        // ) = mpsc::channel(100);
 
         //
         //
@@ -132,32 +138,33 @@ mod tests {
         for test_case in test_cases_list.into_iter() {
             //
             let mut sensors = Vec::new();
+            let name = test_case.sensor.config.name.clone();
             sensors.push(Arc::new(Mutex::new(test_case.sensor)));
 
-            // bulding list of sensors to use it later
-            let sensors_list_copy = sensors.clone();
+            let token = CancellationToken::new();
 
-            tokio::spawn(async move { process_detections_data(sensors_list_copy).await });
-
-            tokio::spawn(async move {
-                reading_data_from_sensors(sensors).await;
-            });
+            spawn_detection_threads(sensors, token.clone());
 
             let mut detections_count = 0;
             let test_time_start = Instant::now();
+
+            println!("current test case: {}", name);
 
             loop {
                 if let Ok(_detection_message) = detections_channel_out.try_recv() {
                     detections_count += 1;
                 }
 
-                if test_time_start.elapsed().as_millis() > test_case.test_timeout_milisecs {
+                if test_time_start.elapsed().as_millis() as u64 > test_case.test_timeout_milisecs {
+                    println!("test timeout.");
                     break;
                 }
 
                 tokio::time::sleep(Duration::from_millis(1)).await;
             }
 
+            // finishing test
+            token.cancel();
             assert_eq!(detections_count, test_case.expected_detections_count);
         }
         println!("finished tests");


### PR DESCRIPTION
This is for new version 2.0.0 due to breaking changes in API. If you use 1.0.0 then you can stay on that version as the main algorithm is the same, but be advised about points 3) and 4)

1) There is a new `spawn_detection_threads()` helper function which is responsible for spawn necessary threads. Previous API required two async functions to be spawn by `tokio::spawn`, now this what this function does, actually. 

The example is updated and now lib will be easier to use.

2) Unit tests are updated - they are now much more deterministic - comments in the tests code are updated to explain how to write these tests correctly to take advantage of deterministic behavior in highly async application

3) `u128` is replaced with `u64` in `MotionSensor` config due to some problems with serde library: https://github.com/serde-rs/json/issues/625. Previously, using `u128` does not require type casting as `as_milis()` for `Instant::Duration` returns `u128` directly. 
This serde issue happened to me couple times and quite annoying so I decide to use `u64` to make this lib much less problematic in some cases. If this issue will be solved in serde then it's not a problem revert this change back.

4) I've added support for `CancellationToken` from `tokio_utils` - it's used to stop sensors tokio threads which is really important especially during unit tests.

5) This lib was also tested on [DFRobot SEN0192 microwave motion sensor](https://wiki.dfrobot.com/MicroWave_Sensor_SKU__SEN0192) - because it's a digital sensor it's also officially supported.